### PR TITLE
Update OpenEye license check badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repostiory tracks the status of the core pieces of infrastructure built, maintained and heavily used by the Open Force Field consortium.
 
-OpenEye License status: ![OE License](https://github.com/openforcefield/status/workflows/OE%20License/badge.svg)
+OpenEye License status:
+[![OE License](https://github.com/openforcefield/status/actions/workflows/oe_license.yml/badge.svg?branch=main)](https://github.com/openforcefield/status/actions/workflows/oe_license.yml)
 
 | Package | Contact | Tests | Documentation | Coverage | Conda build | pre-commit CI
 |:--|:--|:--|:--|:--|:--|:--


### PR DESCRIPTION
The badge now accurately captures the status of the check: https://github.com/openforcefield/status/blob/40775a39aae6537c1a120d64630470d499efd340/README.md