### PR TITLE
Bring full-stack tests back online

### DIFF
--- a/.github/workflows/full-stack.yaml
+++ b/.github/workflows/full-stack.yaml
@@ -98,6 +98,10 @@ jobs:
           --ignore=openff-interchange/openff/interchange/_tests/test_parameter_plugins.py::test_load_handler_plugins
 
     - name: Run QC-adjacent tests
+      # QCarchive 0.55-0.56 doesn't support Apple Silicon, but we want to test QCSubmit
+      # against the most recent versions of upstreams
+      # https://github.com/MolSSI/QCFractal/issues/846
+      if: matrix.os != 'macos-latest'
       run: |
         python -m pytest $PYTEST_ARGS \
           openff-qcsubmit/openff/qcsubmit/_tests/ \

--- a/devtools/conda-envs/full-stack.yaml
+++ b/devtools/conda-envs/full-stack.yaml
@@ -24,12 +24,12 @@ dependencies:
 
     # Recharge
   - qcelemental
-  - qcportal ~=0.50
+  - qcportal ~=0.56
   - qcengine
   - xtb-python
   - geometric =1
 
-  - openff-qcsubmit ~=0.50
+  - openff-qcsubmit ~=0.52
   - qcarchivetesting
   - h5py
 

--- a/devtools/conda-envs/full-stack.yaml
+++ b/devtools/conda-envs/full-stack.yaml
@@ -35,4 +35,5 @@ dependencies:
 
   - openff-nagl
 
-  # gromacs >=2023.4
+  - gromacs >=2024
+  - lammps >=2023.08.02

--- a/devtools/conda-envs/full-stack.yaml
+++ b/devtools/conda-envs/full-stack.yaml
@@ -24,7 +24,7 @@ dependencies:
 
     # Recharge
   - qcelemental
-  - qcportal ~=0.56
+  - qcportal  # hope to pull down 0.56 or newer
   - qcengine
   - xtb-python
   - geometric =1


### PR DESCRIPTION
The last release of LAMMPS includes a test that lacks a decorator to gracefully skip when it's not installed. Might as well just add it to these tests, though.