### PR TITLE
Do not install LAMMPS 2024.06.27

### DIFF
--- a/devtools/conda-envs/full-stack.yaml
+++ b/devtools/conda-envs/full-stack.yaml
@@ -36,4 +36,5 @@ dependencies:
   - openff-nagl
 
   - gromacs >=2024
-  - lammps >=2023.08.02
+  # https://github.com/conda-forge/lammps-feedstock/issues/207
+  - lammps >=2023.08.02,<2024.06.27


### PR DESCRIPTION
## Description
[Something mysterious](https://github.com/conda-forge/lammps-feedstock/issues/207) happened with a recent migration in the LAMMPS feedstock. It baffled me but the exceptionally productive Jan Janssen is on it. For now, just don't install it. This should get us the green ticks back.